### PR TITLE
feat: 관리자 웹 대시보드 실시간 데이터 시각화 및 분석 기능 구현

### DIFF
--- a/admin/admin-signup.html
+++ b/admin/admin-signup.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>관리자 전용 가입 - 보안 모드</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="login-body">
+    <div class="login-container">
+        <h2 style="color: #d946ef;">Master Admin</h2>
+        <p>관리자 마스터 키 인증</p>
+        
+        <form id="secureAdminForm">
+            <div class="input-group">
+                <label>관리자 이메일</label>
+                <input type="email" id="admEmail" placeholder="admin@secure.com" required>
+            </div>
+            
+            <div class="input-group">
+                <label>비밀번호</label>
+                <input type="password" id="admPw" placeholder="보안 비밀번호" required>
+            </div>
+
+            <div class="input-group">
+                <label style="color: #d946ef; font-weight: bold;">마스터 인증 키</label>
+                <input type="password" id="admKey" placeholder="Master Key 입력" required>
+            </div>
+
+            <button type="submit" class="btn-primary" style="background-color: #d946ef;">관리자 등록 실행</button>
+        </form>
+        
+        <div style="margin-top: 1rem;">
+            <a href="index.html">메인으로 돌아가기</a>
+        </div>
+    </div>
+
+    <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/admin/admin.html
+++ b/admin/admin.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>피싱 방지 시스템 - 관리자 대시보드</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+</head>
+<body>
+    <div class="admin-wrapper">
+        <nav class="sidebar">
+            <div class="sidebar-header">
+                <h3>피싱 방지 시스템</h3>
+                <span>관리자 대시보드</span>
+            </div>
+            <ul class="menu">
+                <li class="active" onclick="switchTab('dashboard')">
+                    <i class="fas fa-chart-line"></i> 실시간 대시보드
+                </li>
+                <li onclick="switchTab('reports')">
+                    <i class="fas fa-file-alt"></i> 신고 사례 관리
+                </li>
+                <li onclick="logout()">
+                    <i class="fas fa-sign-out-alt"></i> 로그아웃
+                </li>
+            </ul>
+        </nav>
+
+        <main class="content">
+            <section id="dashboard-section" class="page-section" style="height: 100%; display: flex; flex-direction: column;">
+                <div class="section-header">
+                    <h2>전체 대시보드</h2>
+                    <p>시스템 현황 및 통계를 실시간으로 확인하세요.</p>
+                </div>
+
+                <div class="stats-summary">
+                    <div class="stat-card">
+                        <div class="stat-icon" style="background: #e0e7ff; color: #3730a3;">
+                            <i class="fas fa-users"></i>
+                        </div>
+                        <div class="stat-info">
+                            <h4>총 사용자 수</h4>
+                            <p id="totalUsersCount">- 명</p>
+                        </div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="stat-icon" style="background: #dcfce7; color: #166534;">
+                            <i class="fas fa-search-location"></i>
+                        </div>
+                        <div class="stat-info">
+                            <h4>총 분석 건수</h4>
+                            <p id="totalReportsCount">- 건</p>
+                        </div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="stat-icon" style="background: #ffedd5; color: #9a3412;">
+                            <i class="fas fa-calendar-week"></i>
+                        </div>
+                        <div class="stat-info">
+                            <h4>최근 7일 분석</h4>
+                            <p id="recentReportsCount">- 건</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="charts-grid">
+                    <div class="card chart-card">
+                        <h3>📈 위험도 발생 추이 (최근 7일)</h3>
+                        <div class="canvas-container">
+                            <canvas id="trendChart"></canvas>
+                        </div>
+                    </div>
+
+                    <div class="card chart-card">
+                        <h3>🔍 사기 유형별 분류 (상위순)</h3>
+                        <div class="canvas-container">
+                            <canvas id="categoryChart"></canvas>
+                        </div>
+                    </div>
+
+                    <div class="card chart-card">
+                        <h3>⚠️ 사용자 위험도 비율</h3>
+                        <div class="canvas-container" style="max-height: 200px;"> <canvas id="riskRatioChart"></canvas>
+                        </div>
+                        <div id="riskTextSummary" class="risk-summary">
+                            <div class="risk-row">
+                                <span class="dot warning"></span> WARNING 이상 비율: <strong id="riskHighRatio">- %</strong>
+                            </div>
+                            <div class="risk-row">
+                                <span class="dot stop"></span> STOP 진입 전 감지: <strong id="riskPreventCount">- 건</strong>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card chart-card">
+                        <h3>👥 연령대별/성별 의심 신고</h3>
+                        <div class="canvas-container">
+                            <canvas id="demographicChart"></canvas>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section id="reports-section" class="page-section hidden">
+                <div class="section-header">
+                    <h2>신고 사례 관리</h2>
+                    <p>사용자가 신고한 모든 사례를 확인하고 분석하세요.</p>
+                </div>
+
+                <div class="filter-bar">
+                    <input type="text" id="searchInput" placeholder="내용 검색" onkeyup="filterReports()">
+                    <select id="categoryFilter" onchange="filterReports()">
+                        <option value="">전체 분류</option>
+                        <option value="기관 사칭">기관 사칭</option>
+                        <option value="지인 사칭">지인 사칭</option>
+                        <option value="링크/앱 유도">링크/앱 유도</option>
+                        <option value="투자 사기">투자 사기</option>
+                        <option value="관계형 사기">관계형 사기</option>
+                        <option value="협박 사기">협박 사기</option>
+                    </select>
+                </div>
+
+                <div class="table-container card">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>신고 ID</th>
+                                <th>요약</th>
+                                <th>위험도</th>
+                                <th>분류</th>
+                                <th>신고 일시</th>
+                                <th>관리</th>
+                            </tr>
+                        </thead>
+                        <tbody id="reportTableBody"></tbody>
+                    </table>
+                </div>
+                
+                <div class="pagination-container" id="paginationControls"></div>
+                <div id="pageInfo" style="margin-top: 10px; text-align: right; font-size: 0.9rem; color: #666;"></div>
+            </section>
+        </main>
+    </div>
+
+    <div id="detailModal" class="modal hidden">
+        <div class="modal-content">
+            <div class="modal-header">
+                <div>
+                    <span id="modalRiskBadge" class="badge"></span>
+                    <span id="modalDate" style="color: #666; font-size: 0.9rem; margin-left: 10px;"></span>
+                </div>
+                <span class="close-btn" onclick="closeModal()">&times;</span>
+            </div>
+            
+            <div class="modal-body">
+                <h3 id="modalSummaryTitle" style="margin-bottom: 1.5rem; font-size: 1.1rem; line-height: 1.5;"></h3>
+
+                <div class="reporter-card">
+                    <div class="reporter-icon"><i class="fas fa-user-secret"></i></div>
+                    <div>
+                        <div style="font-weight: bold;">신고자 정보</div>
+                        <div id="modalReporterInfo" style="font-size: 0.9rem; color: #666; margin-top: 4px;">-</div>
+                    </div>
+                </div>
+
+                <div class="advice-card">
+                    <div style="font-weight: bold; margin-bottom: 8px;"><i class="fas fa-shield-alt"></i> AI 보안 조언</div>
+                    <div id="modalAdvice" style="font-size: 0.9rem; line-height: 1.5; color: #374151;">-</div>
+                </div>
+
+                <div class="modal-grid-row">
+                    <div class="info-block">
+                        <label>컨텍스트 정보</label>
+                        <div class="box-light" id="modalContext"></div>
+                        <div id="modalRiskFactors" style="margin-top: 10px;"></div>
+                    </div>
+                    <div class="info-block">
+                        <label>첨부 이미지</label>
+                        <div id="modalImageContainer" class="image-box"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/admin/app.js
+++ b/admin/app.js
@@ -1,0 +1,500 @@
+// 1. Firebase 설정 (본인의 키로 교체 필요)
+const firebaseConfig = {
+    apiKey: "YOUR_API_KEY",
+    authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
+    projectId: "YOUR_PROJECT_ID",
+    storageBucket: "YOUR_PROJECT_ID.appspot.com",
+    messagingSenderId: "SENDER_ID",
+    appId: "APP_ID"
+};
+
+if (!firebase.apps.length) {
+    firebase.initializeApp(firebaseConfig);
+}
+const db = firebase.firestore();
+const auth = firebase.auth();
+
+// 전역 변수
+let globalReportsData = [];
+let globalUsersMap = {};
+let charts = { trend: null, ratio: null, category: null, demo: null };
+let currentPage = 1;
+const rowsPerPage = 10;
+
+console.log("🚀 [App.js] 로드 완료.");
+
+// ============================================================
+// 2. 헬퍼 함수
+// ============================================================
+
+async function generateHash(message) {
+    const msgBuffer = new TextEncoder().encode(message);
+    const hashBuffer = await crypto.subtle.digest('SHA-256', msgBuffer);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+// 사기 유형 라벨링
+function getCategoryLabel(code) {
+    if (!code) return '분류 없음';
+    const str = String(code).toUpperCase().trim();
+    
+    if (str.includes('INSTITUTION') || str.includes('기관')) return '기관 사칭';
+    if (str.includes('ACQUAINTANCE') || str.includes('지인')) return '지인 사칭';
+    if (str.includes('LINK') || str.includes('URL') || str.includes('앱')) return '링크/앱 유도';
+    if (str.includes('INVESTMENT') || str.includes('투자')) return '투자 사기';
+    if (str.includes('ROMANCE') || str.includes('로맨스')) return '관계형 사기';
+    if (str.includes('BLACKMAIL') || str.includes('협박')) return '협박 사기';
+    if (str.includes('MALICIOUS') || str.includes('악성')) return '악성 앱';
+    if (str.includes('PHISHING') || str.includes('피싱')) return '피싱';
+    
+    return '기타'; 
+}
+
+function mapRiskLevel(dbLevel) {
+    if(!dbLevel) return { class: 'caution', label: 'UNKNOWN' };
+    const upper = String(dbLevel).toUpperCase();
+    if (upper.includes('STOP')) return { class: 'stop', label: 'STOP' };
+    if (upper.includes('WARN')) return { class: 'warning', label: 'WARNING' };
+    if (upper.includes('CAUTION')) return { class: 'caution', label: 'CAUTION' };
+    if (upper.includes('SAFE')) return { class: 'safe', label: 'SAFE' };
+    return { class: 'caution', label: 'UNKNOWN' };
+}
+
+// 나이 계산
+function calculateAgeGroup(input) {
+    if (!input) return '미상';
+    
+    const numStr = String(input).replace(/[^0-9]/g, '');
+    const num = parseInt(numStr);
+    if (isNaN(num)) return '미상';
+
+    let age = 0;
+    const currentYear = new Date().getFullYear();
+
+    if (num > 0 && num < 100) age = num; 
+    else if (numStr.length >= 4) { 
+        const birthYear = parseInt(numStr.substring(0, 4));
+        age = currentYear - birthYear;
+    } else {
+        return '미상';
+    }
+
+    if (age < 20) return '10대 이하';
+    if (age < 30) return '20대';
+    if (age < 40) return '30대';
+    if (age < 50) return '40대';
+    if (age < 60) return '50대';
+    return '60대 이상';
+}
+
+// 성별 인식
+function normalizeGender(input) {
+    if (!input) return '미상';
+    const g = String(input).toLowerCase().trim();
+    
+    if (g.includes('여') || g.includes('f') || g.includes('w')) return '여성';
+    if (g.includes('남') || g.includes('m')) return '남성';
+    return '미상';
+}
+
+// ============================================================
+// 3. 인증 로직
+// ============================================================
+const loginForm = document.getElementById('loginForm');
+if (loginForm) {
+    loginForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        auth.signInWithEmailAndPassword(email, password)
+            .then(async (res) => {
+                const adminDoc = await db.collection('admins').doc(res.user.uid).get();
+                if (adminDoc.exists) window.location.href = "admin.html";
+                else { alert("⛔ 권한 없음"); auth.signOut(); }
+            })
+            .catch(e => alert("로그인 실패: " + e.message));
+    });
+}
+
+const secureAdminForm = document.getElementById('secureAdminForm');
+if (secureAdminForm) {
+    secureAdminForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const email = document.getElementById('admEmail').value.trim();
+        const password = document.getElementById('admPw').value;
+        const inputKey = document.getElementById('admKey').value.trim();
+
+        try {
+            const hashedKey = await generateHash(inputKey);
+            const docRef = await db.collection('admin_codes').doc(hashedKey).get();
+            if (!docRef.exists) { alert("⛔ 인증 키 불일치"); return; }
+
+            const userCredential = await auth.createUserWithEmailAndPassword(email, password);
+            await db.collection('admins').doc(userCredential.user.uid).set({
+                email: email, role: 'master', createdAt: new Date(), uid: userCredential.user.uid
+            });
+            alert("🎉 관리자 등록 성공!");
+            window.location.href = "admin.html";
+        } catch (error) { alert("오류: " + error.message); }
+    });
+}
+
+// ============================================================
+// 4. 대시보드 로직
+// ============================================================
+if (window.location.pathname.includes("admin.html")) {
+    
+    window.onload = function() {
+        initRealTimeListeners();
+    };
+
+    window.switchTab = function(tabName) {
+        document.getElementById('dashboard-section').classList.add('hidden');
+        document.getElementById('reports-section').classList.add('hidden');
+        document.querySelectorAll('.menu li').forEach(li => li.classList.remove('active'));
+        
+        if (tabName === 'dashboard') {
+            document.getElementById('dashboard-section').classList.remove('hidden');
+            document.querySelector('.menu li:nth-child(1)').classList.add('active');
+        } else {
+            document.getElementById('reports-section').classList.remove('hidden');
+            document.querySelector('.menu li:nth-child(2)').classList.add('active');
+        }
+    }
+    window.logout = function() { auth.signOut().then(() => window.location.href = "index.html"); }
+
+    function initRealTimeListeners() {
+        // 1. 유저 정보
+        db.collection('users').onSnapshot(snapshot => {
+            let userCount = 0;
+            globalUsersMap = {};
+
+            snapshot.forEach(doc => {
+                userCount++;
+                const uData = doc.data();
+                const ageInput = uData.age || uData.birthDate || uData.birth || uData.birthday;
+                
+                globalUsersMap[doc.id] = {
+                    age: calculateAgeGroup(ageInput),
+                    gender: normalizeGender(uData.gender),
+                    region: uData.region || '전국'
+                };
+            });
+
+            const userEl = document.getElementById('totalUsersCount');
+            if(userEl) userEl.innerText = `${userCount} 명`;
+
+            if (globalReportsData.length > 0 || userCount > 0) {
+                processAndRender(globalReportsData);
+            }
+        });
+
+        // 2. 신고 내역
+        db.collection('community_reports').orderBy('timestamp', 'desc').onSnapshot(snapshot => {
+            const reports = [];
+            
+            snapshot.forEach(doc => {
+                const data = doc.data();
+                let rawDateObj = null;
+                let formattedDate = "-";
+                if (data.timestamp) {
+                    rawDateObj = typeof data.timestamp.toDate === 'function' ? data.timestamp.toDate() : new Date(data.timestamp);
+                    formattedDate = rawDateObj.toLocaleString();
+                }
+
+                const rawCat = data.archetype || data.category || data.type || 'Unknown';
+                const catLabel = getCategoryLabel(rawCat);
+
+                reports.push({
+                    id: doc.id,
+                    uid: data.reporterUid,
+                    summary: data.summary || '내용 없음',
+                    riskObj: mapRiskLevel(data.riskLevel), 
+                    category: catLabel, 
+                    date: formattedDate,
+                    rawDate: rawDateObj, 
+                    riskFactors: data.riskFactors || "", 
+                    advice: data.advice || "",
+                    context: data.contextInfo || "",
+                    imageUrl: data.imageUrl || null
+                });
+            });
+
+            globalReportsData = reports;
+            processAndRender(globalReportsData);
+        }, error => console.error("❌ 실시간 연동 에러:", error));
+    }
+
+    function processAndRender(reports) {
+        // 조인
+        const joinedData = reports.map(item => {
+            const uInfo = globalUsersMap[item.uid] || { age: '미상', gender: '미상' };
+            return { ...item, reporter: uInfo };
+        });
+
+        // 상단 카운트
+        const totalEl = document.getElementById('totalReportsCount');
+        const recentEl = document.getElementById('recentReportsCount');
+        if(totalEl) totalEl.innerText = `${joinedData.length} 건`;
+
+        const sevenDaysAgo = new Date();
+        sevenDaysAgo.setDate(new Date().getDate() - 7);
+        const recentCount = joinedData.filter(r => r.rawDate && r.rawDate >= sevenDaysAgo).length;
+        if(recentEl) recentEl.innerText = `${recentCount} 건`;
+
+        renderReportsTable(joinedData);
+        renderCharts(joinedData);
+    }
+
+    // ------------------------------------------------------------
+    // [차트] 연령대별 차트 디자인 원복 (나란히 배치)
+    // ------------------------------------------------------------
+    function renderCharts(reportData) {
+        
+        // 초기화
+        let dailyCounts = {};
+        let riskCounts = { 'SAFE': 0, 'CAUTION': 0, 'WARNING': 0, 'STOP_IMMEDIATELY': 0 };
+        let catCounts = {}; 
+        
+        let demoCounts = {
+            '10대 이하': { '남성': 0, '여성': 0 },
+            '20대': { '남성': 0, '여성': 0 },
+            '30대': { '남성': 0, '여성': 0 },
+            '40대': { '남성': 0, '여성': 0 },
+            '50대': { '남성': 0, '여성': 0 },
+            '60대 이상': { '남성': 0, '여성': 0 },
+            '미상': { '남성': 0, '여성': 0 } 
+        };
+
+        const today = new Date();
+        for(let i=6; i>=0; i--) {
+            const d = new Date();
+            d.setDate(today.getDate() - i);
+            const dateStr = `${d.getMonth()+1}/${d.getDate()}`;
+            dailyCounts[dateStr] = 0;
+        }
+
+        // 리포트 루프
+        reportData.forEach(item => {
+            // 위험도
+            if (item.riskObj.class === 'safe') riskCounts['SAFE']++;
+            else if (item.riskObj.class === 'caution') riskCounts['CAUTION']++;
+            else if (item.riskObj.class === 'warning') riskCounts['WARNING']++;
+            else if (item.riskObj.class === 'stop') riskCounts['STOP_IMMEDIATELY']++;
+
+            // 사기 유형
+            const cat = item.category || '기타';
+            catCounts[cat] = (catCounts[cat] || 0) + 1;
+
+            // 추이
+            if (item.rawDate) {
+                const m = item.rawDate.getMonth() + 1;
+                const d = item.rawDate.getDate();
+                const dateKey = `${m}/${d}`;
+                if (dailyCounts.hasOwnProperty(dateKey)) dailyCounts[dateKey]++;
+            }
+        });
+
+        // 유저 루프 (인구통계)
+        Object.values(globalUsersMap).forEach(user => {
+            const age = user.age || '미상';
+            const gender = user.gender || '미상';
+            
+            if (demoCounts[age] && demoCounts[age][gender] !== undefined) {
+                demoCounts[age][gender]++;
+            }
+        });
+
+        // 차트 그리기
+        const commonOptions = {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: { legend: { position: 'bottom' } }
+        };
+
+        const initChart = (id, type, data, opts) => {
+            const ctx = document.getElementById(id);
+            if (!ctx) return;
+            const key = id.replace('Chart', '').replace('riskRatio', 'ratio');
+            if (charts[key]) charts[key].destroy();
+            charts[key] = new Chart(ctx, { type, data, options: opts });
+        }
+
+        // [1] 위험도 추이
+        initChart('trendChart', 'line', {
+            labels: Object.keys(dailyCounts),
+            datasets: [{
+                label: '일별 신고',
+                data: Object.values(dailyCounts),
+                borderColor: '#ef4444',
+                backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                tension: 0.3,
+                fill: true
+            }]
+        }, commonOptions);
+
+        // [2] 사기 유형 (세로 막대형으로 복구 + 데이터 확인용 로그)
+        const sortedCats = Object.entries(catCounts)
+            .map(([key, val]) => ({key, val}))
+            .sort((a, b) => b.val - a.val);
+
+        console.log("📊 사기 유형 데이터:", sortedCats); // 데이터 확인용
+
+        if (sortedCats.length === 0) sortedCats.push({key: '데이터 없음', val: 0});
+
+        initChart('categoryChart', 'bar', {
+            labels: sortedCats.map(x => x.key),
+            datasets: [{
+                label: '건수',
+                data: sortedCats.map(x => x.val),
+                backgroundColor: sortedCats.map((_, i) => i === 0 ? '#3b82f6' : '#e5e7eb'), // 1위 파랑
+                borderRadius: 4
+            }]
+        }, commonOptions); // indexAxis 삭제 -> 기본 세로형
+
+        // [3] 위험도 비율
+        const totalRisks = reportData.length;
+        const warningCount = riskCounts['WARNING'];
+        const stopCount = riskCounts['STOP_IMMEDIATELY'];
+        const warningRatio = totalRisks > 0 ? Math.round(((warningCount + stopCount) / totalRisks) * 100) : 0;
+        
+        const riskHighEl = document.getElementById('riskHighRatio');
+        if(riskHighEl) riskHighEl.innerText = `${warningRatio}%`;
+        
+        const riskPrevEl = document.getElementById('riskPreventCount');
+        if(riskPrevEl) riskPrevEl.innerText = `${warningCount} 건`;
+
+        initChart('riskRatioChart', 'doughnut', {
+            labels: ['SAFE', 'CAUTION', 'WARNING', 'STOP'],
+            datasets: [{
+                data: [riskCounts['SAFE'], riskCounts['CAUTION'], warningCount, stopCount],
+                backgroundColor: ['#10b981', '#f59e0b', '#f97316', '#ef4444'],
+                borderWidth: 0
+            }]
+        }, commonOptions);
+
+        // [4] 인구통계 (복구: 파란색/분홍색 막대 나란히)
+        const ageLabels = ['10대 이하', '20대', '30대', '40대', '50대', '60대 이상'];
+        const maleData = ageLabels.map(l => demoCounts[l]['남성']);
+        const femaleData = ageLabels.map(l => demoCounts[l]['여성']);
+
+        initChart('demographicChart', 'bar', {
+            labels: ageLabels,
+            datasets: [
+                { label: '남성', data: maleData, backgroundColor: '#60a5fa' }, // 파란색
+                { label: '여성', data: femaleData, backgroundColor: '#f472b6' }  // 분홍색
+            ]
+        }, commonOptions); // scales 옵션 삭제 -> 기본 Grouped Bar Chart
+    }
+
+    // 테이블 렌더링
+    window.renderReportsTable = function(data) {
+        const tbody = document.getElementById('reportTableBody');
+        const paginationEl = document.getElementById('paginationControls');
+        const pageInfoEl = document.getElementById('pageInfo');
+        
+        if(!tbody) return;
+        tbody.innerHTML = '';
+        paginationEl.innerHTML = '';
+
+        if (data.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="6" style="text-align:center; padding: 2rem;">데이터가 없습니다.</td></tr>';
+            pageInfoEl.innerText = '0 건';
+            return;
+        }
+
+        const startIndex = (currentPage - 1) * rowsPerPage;
+        const endIndex = startIndex + rowsPerPage;
+        const paginatedItems = data.slice(startIndex, endIndex);
+
+        paginatedItems.forEach(item => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td style="color: #3b82f6; font-weight:bold;">${item.id.substring(0, 8)}...</td>
+                <td>${item.summary.length > 20 ? item.summary.substring(0, 20) + '...' : item.summary}</td>
+                <td><span class="badge ${item.riskObj.class}">${item.riskObj.label}</span></td>
+                <td><span class="cat-badge" style="background:#f3f4f6; color:#374151; font-weight:600; padding:4px 8px; border-radius:4px;">${item.category}</span></td>
+                <td>${item.date}</td>
+                <td><button class="btn-primary" style="padding: 0.3rem 0.6rem; font-size:0.8rem;" onclick="openDetail('${item.id}')">상세보기</button></td>
+            `;
+            tbody.appendChild(tr);
+        });
+
+        const totalPages = Math.ceil(data.length / rowsPerPage);
+        const createBtn = (text, disabled, onClick) => {
+            const btn = document.createElement('button');
+            btn.innerText = text;
+            btn.className = 'page-btn';
+            btn.disabled = disabled;
+            btn.onclick = onClick;
+            return btn;
+        };
+
+        paginationEl.appendChild(createBtn('<', currentPage === 1, () => { currentPage--; renderReportsTable(data); }));
+        
+        let startPage = Math.max(1, currentPage - 2);
+        let endPage = Math.min(totalPages, currentPage + 2);
+        for(let i=startPage; i<=endPage; i++) {
+            const btn = document.createElement('button');
+            btn.innerText = i;
+            btn.className = `page-btn ${i === currentPage ? 'active' : ''}`;
+            btn.onclick = () => { currentPage = i; renderReportsTable(data); };
+            paginationEl.appendChild(btn);
+        }
+
+        paginationEl.appendChild(createBtn('>', currentPage === totalPages, () => { currentPage++; renderReportsTable(data); }));
+        pageInfoEl.innerText = `총 ${data.length}건 중 ${startIndex+1}-${Math.min(endIndex, data.length)} 표시`;
+    }
+
+    // 필터
+    window.filterReports = function() {
+        currentPage = 1;
+        const keyword = document.getElementById('searchInput').value.toLowerCase();
+        const categoryFilter = document.getElementById('categoryFilter').value;
+        
+        const joinedData = globalReportsData.map(item => {
+            const uInfo = globalUsersMap[item.uid] || { age: '미상', gender: '미상' };
+            return { ...item, reporter: uInfo };
+        });
+
+        const filtered = joinedData.filter(item => {
+            const matchKeyword = (item.summary.toLowerCase().includes(keyword) || item.id.toLowerCase().includes(keyword));
+            const matchCategory = categoryFilter === "" || item.category === categoryFilter;
+            return matchKeyword && matchCategory;
+        });
+        renderReportsTable(filtered);
+    }
+
+    // 모달
+    window.openDetail = function(id) {
+        const item = globalReportsData.find(r => r.id === id);
+        if(!item) return;
+
+        const uInfo = globalUsersMap[item.uid] || { age: '미상', gender: '미상', region: '전국' };
+        
+        document.getElementById('modalSummaryTitle').innerText = item.summary;
+        document.getElementById('modalReporterInfo').innerText = `${uInfo.age} · ${uInfo.gender} · ${uInfo.region}`;
+        document.getElementById('modalDate').innerText = item.date;
+        document.getElementById('modalAdvice').innerText = item.advice || "조언 없음";
+        document.getElementById('modalContext').innerText = item.context || "-";
+        
+        const badge = document.getElementById('modalRiskBadge');
+        badge.className = `badge ${item.riskObj.class}`;
+        badge.innerText = item.riskObj.label;
+
+        const riskBox = document.getElementById('modalRiskFactors');
+        riskBox.innerHTML = '';
+        if(item.riskFactors) {
+            item.riskFactors.split(/[•\n]+/).filter(r => r.trim()).forEach(r => {
+                riskBox.innerHTML += `<div class="risk-item" style="color:#b91c1c; background:#fef2f2; padding:5px; margin-top:5px; border-radius:4px; font-size:0.9rem;">⚠️ ${r.trim()}</div>`;
+            });
+        }
+
+        const imgBox = document.getElementById('modalImageContainer');
+        imgBox.innerHTML = item.imageUrl ? `<img src="${item.imageUrl}" style="width:100%;height:100%;object-fit:contain; cursor:pointer;" onclick="window.open(this.src)">` : '<span style="color:#999; font-size:0.8rem;">이미지 없음</span>';
+
+        document.getElementById('detailModal').classList.remove('hidden');
+    }
+    window.closeModal = function() { document.getElementById('detailModal').classList.add('hidden'); }
+}

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="ko">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>피싱 방지 시스템 - 관리자 로그인</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body class="login-body">
+    <div class="login-container">
+        <h2>관리자 로그인</h2>
+        <p>피싱 방지 시스템 대시보드</p>
+        <form id="loginForm">
+            <div class="input-group">
+                <label>이메일</label>
+                <input type="email" id="email" placeholder="admin@example.com" required>
+            </div>
+            <div class="input-group">
+                <label>비밀번호</label>
+                <input type="password" id="password" placeholder="********" required>
+            </div>
+            <div class="input-group">
+                <label>관리자 인증 키</label>
+                <input type="password" id="adminKey" placeholder="Secret Key 입력" required>
+            </div>
+            <button type="submit" class="btn-primary">로그인</button>
+        </form>
+        <div style="margin-top: 1rem; font-size: 0.9rem;">
+            <a href="admin-signup.html" style="color: var(--text-light); text-decoration: none;">
+                관리자 계정 생성하기
+            </a>
+        </div>
+    </div>
+
+    <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+    <script src="app.js"></script>
+</body>
+
+</html>

--- a/admin/style.css
+++ b/admin/style.css
@@ -1,0 +1,211 @@
+:root {
+    --primary-color: #3b82f6;
+    --bg-color: #f3f4f6;
+    --sidebar-width: 250px;
+    --text-dark: #1f2937;
+    --text-light: #6b7280;
+    --card-bg: #ffffff;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; font-family: 'Pretendard', sans-serif; }
+
+body { overflow: hidden; height: 100vh; }
+
+/* =========================================
+   [복구] 로그인 & 회원가입 페이지 스타일
+   ========================================= */
+.login-body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    background: var(--bg-color);
+    overflow: hidden; /* 스크롤 방지 */
+}
+
+.login-container {
+    background: white;
+    padding: 2.5rem;
+    border-radius: 12px;
+    width: 400px;
+    box-shadow: 0 10px 25px rgba(0,0,0,0.1);
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+}
+
+.login-container h2 {
+    margin-bottom: 0.5rem;
+    color: var(--text-dark);
+    font-size: 1.5rem;
+}
+
+.login-container p {
+    color: var(--text-light);
+    margin-bottom: 2rem;
+    font-size: 0.95rem;
+}
+
+.input-group {
+    margin-bottom: 1.2rem;
+    text-align: left;
+}
+
+.input-group label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-dark);
+}
+
+.input-group input {
+    width: 100%;
+    padding: 0.8rem;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    font-size: 0.95rem;
+    transition: border-color 0.2s;
+}
+
+.input-group input:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+/* 버튼 스타일 (로그인 화면용) */
+.login-container .btn-primary {
+    width: 100%;
+    padding: 0.9rem;
+    background: var(--primary-color);
+    color: white;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 600;
+    transition: background 0.2s;
+    margin-top: 0.5rem;
+}
+
+.login-container .btn-primary:hover {
+    background: #2563eb;
+}
+
+/* 링크 스타일 */
+.login-container a {
+    color: var(--text-light);
+    text-decoration: none;
+    font-size: 0.9rem;
+    transition: color 0.2s;
+}
+
+.login-container a:hover {
+    color: var(--primary-color);
+    text-decoration: underline;
+}
+
+.admin-wrapper { display: flex; height: 100vh; overflow: hidden; }
+
+/* 사이드바 */
+.sidebar { width: var(--sidebar-width); background: white; border-right: 1px solid #e5e7eb; display: flex; flex-direction: column; z-index: 10; }
+.sidebar-header { padding: 2rem 1.5rem; border-bottom: 1px solid #f0f0f0; }
+.sidebar-header h3 { font-size: 1.2rem; color: var(--text-dark); }
+.menu { list-style: none; margin-top: 1rem; }
+.menu li { padding: 1rem 1.5rem; cursor: pointer; color: var(--text-light); transition: 0.2s; display: flex; align-items: center; gap: 10px; }
+.menu li:hover, .menu li.active { background: #eff6ff; color: var(--primary-color); border-right: 3px solid var(--primary-color); }
+
+/* 메인 콘텐츠 */
+.content { 
+    flex: 1; padding: 1.5rem; background: var(--bg-color); 
+    height: 100vh; display: flex; flex-direction: column; overflow: hidden; 
+}
+
+.section-header { margin-bottom: 1rem; flex-shrink: 0; }
+.hidden { display: none !important; }
+
+/* 통계 요약 카드 */
+.stats-summary {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; margin-bottom: 1rem; flex-shrink: 0;
+}
+.stat-card {
+    background: white; padding: 1.2rem; border-radius: 10px; border: 1px solid #e5e7eb;
+    display: flex; align-items: center; box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+.stat-icon {
+    width: 50px; height: 50px; border-radius: 12px; display: flex; align-items: center; justify-content: center;
+    font-size: 1.5rem; margin-right: 1rem;
+}
+.stat-info h4 { margin: 0; font-size: 0.9rem; color: #6b7280; font-weight: 500; }
+.stat-info p { margin: 5px 0 0 0; font-size: 1.5rem; font-weight: 700; color: #1f2937; }
+
+/* 차트 그리드 */
+.charts-grid { 
+    display: grid; grid-template-columns: 1fr 1fr; grid-template-rows: 1fr 1fr;
+    gap: 1rem; flex: 1; height: 100%; min-height: 0; 
+}
+.card { 
+    background: white; padding: 1rem; border-radius: 10px; border: 1px solid #e5e7eb;
+    display: flex; flex-direction: column; height: 100%; min-height: 0; overflow: hidden;
+}
+.canvas-container { flex: 1; position: relative; width: 100%; min-height: 0; }
+
+/* [NEW] 위험도 텍스트 요약 */
+.risk-summary {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid #f0f0f0;
+    display: flex;
+    justify-content: space-around;
+    font-size: 0.9rem;
+    color: #4b5563;
+}
+.risk-row { display: flex; align-items: center; gap: 6px; }
+.risk-row strong { color: #1f2937; font-size: 1rem; }
+.dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.dot.warning { background: #f97316; }
+.dot.stop { background: #ef4444; }
+
+
+/* 테이블 및 필터 */
+.filter-bar { display: flex; gap: 1rem; margin-bottom: 1rem; }
+.filter-bar input, .filter-bar select { padding: 0.6rem; border: 1px solid #ddd; border-radius: 5px; flex: 1; }
+.table-container { overflow-y: auto; flex: 1; background: white; border-radius: 10px; padding: 0; }
+table { width: 100%; border-collapse: collapse; text-align: left; }
+th, td { padding: 1rem; border-bottom: 1px solid #f0f0f0; font-size: 0.9rem; }
+th { background: #f9fafb; position: sticky; top: 0; }
+
+/* 배지 & 기타 스타일 */
+.badge { padding: 4px 8px; border-radius: 6px; font-size: 0.75rem; font-weight: bold; }
+.cat-badge { padding: 4px 8px; border-radius: 6px; font-size: 0.75rem; font-weight: 600; display: inline-block; }
+.cat-institution { background: #e0e7ff; color: #3730a3; border: 1px solid #c7d2fe; }
+.cat-acquaintance { background: #dcfce7; color: #166534; border: 1px solid #bbf7d0; }
+.cat-link { background: #ffedd5; color: #9a3412; border: 1px solid #fed7aa; }
+.cat-investment { background: #fae8ff; color: #86198f; border: 1px solid #f0abfc; }
+.cat-malicious { background: #fee2e2; color: #991b1b; border: 1px solid #fecaca; }
+.cat-etc { background: #f3f4f6; color: #4b5563; border: 1px solid #e5e7eb; }
+
+.safe { background: #d1fae5; color: #065f46; }
+.caution { background: #fef3c7; color: #92400e; }
+.warning { background: #ffedd5; color: #9a3412; }
+.stop { background: #fee2e2; color: #991b1b; }
+
+/* 모달 및 페이지네이션 */
+.modal { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); display: flex; justify-content: center; align-items: center; z-index: 1000; }
+.modal-content { background: white; width: 600px; border-radius: 12px; padding-bottom: 1.5rem; max-height: 90vh; overflow-y: auto; }
+.modal-header { padding: 1.2rem 1.5rem; display: flex; justify-content: space-between; align-items: center; }
+.modal-body { padding: 0 1.5rem; }
+.reporter-card { display: flex; align-items: center; background: white; border: 1px solid #eee; padding: 1rem; border-radius: 10px; margin-bottom: 1rem; }
+.reporter-icon { width: 40px; height: 40px; background: #eff6ff; color: #3b82f6; border-radius: 50%; display: flex; align-items: center; justify-content: center; margin-right: 1rem; }
+.advice-card { background: #f0f9ff; border: 1px solid #bae6fd; padding: 1rem; border-radius: 10px; margin-bottom: 1.5rem; color: #0c4a6e; }
+.modal-grid-row { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; }
+.box-light { background: #f9fafb; padding: 1rem; border-radius: 5px; font-size: 0.9rem; }
+.image-box { width: 100%; height: 200px; background: #f9fafb; border: 1px dashed #d1d5db; border-radius: 8px; display: flex; align-items: center; justify-content: center; overflow: hidden; }
+.close-btn { font-size: 1.5rem; cursor: pointer; }
+
+.pagination-container { display: flex; justify-content: center; gap: 5px; margin-top: 1rem; }
+.page-btn { padding: 6px 12px; border: 1px solid #ddd; background: white; cursor: pointer; border-radius: 4px; color: #374151; font-size: 0.9rem; }
+.page-btn:hover { background: #f3f4f6; }
+.page-btn.active { background: var(--primary-color); color: white; border-color: var(--primary-color); font-weight: bold; }
+.page-btn:disabled { opacity: 0.5; cursor: not-allowed; }


### PR DESCRIPTION
# Pull Request Template

## Summary
- 관리자 웹 대시보드의 데이터 시각화 기능을 고도화하고, 실시간 통계 분석 로직을 구현했습니다.

## Changes
- **실시간 데이터 동기화 구현**: Firestore의 `onSnapshot` 리스너를 연동하여 유저 유입 및 신고 현황을 새로고침 없이 모니터링할 수 있도록 구축했습니다.
- **데이터 집계 로직 재설계**: 신고 건수 기준이 아닌, 실제 가입 유저 수(`Users` 컬렉션)를 기반으로 인구통계가 산출되도록 로직을 수정했습니다.
- **차트 시각화 및 UI 개선**:
  - **사기 유형 차트**: 내림차순 정렬 및 최다 발생 유형 강조 색상(Blue)을 적용했습니다.
  - **인구통계 차트**: 연령대별/성별 분포를 직관적으로 비교할 수 있도록 Grouped Bar Chart로 변경했습니다.
  - **위험도 지표**: 도넛 차트 하단에 'WARNING 이상 비율' 및 '위험 예방 건수' 요약 텍스트를 추가했습니다.
- **테이블 페이지네이션 도입**: 대량의 신고 리스트를 효율적으로 관리하기 위해 10개 단위 페이지네이션 기능을 추가했습니다.
- **데이터 정규화**: 성별 및 나이 데이터의 다양한 입력 형식을 처리하는 예외 방어 로직을 강화했습니다.

## Testing
- [ ] Not run (reason):
- [ ] Unit
- [ ] Integration
- [x] Manual (Firestore 실시간 데이터 입력 테스트 및 차트 렌더링 검증 완료)

## Risks / Rollback
- Risk: 실시간 리스너 다수 연결 시 Firestore 읽기 할당량 증가 우려
- Rollback plan: `git checkout main` 및 기존 정적 데이터 로딩 방식 복구

## References
- Related: Closes #16

