### PR TITLE
feat: 웹 신고 접수 AI 분석 연동 및 커뮤니티 통합 조회 기능 구현

### DIFF
--- a/web-backend/build.gradle
+++ b/web-backend/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 tasks.named('test') {

--- a/web-backend/src/main/java/com/smishingprevention/webbackend/FirebaseConfig.java
+++ b/web-backend/src/main/java/com/smishingprevention/webbackend/FirebaseConfig.java
@@ -26,6 +26,7 @@ public class FirebaseConfig {
             // 2. 읽어온 키로 옵션을 설정합니다.
             FirebaseOptions options = FirebaseOptions.builder()
                     .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .setStorageBucket("keyboardapp-f2bfb.firebasestorage.app")
                     .build();
 
             // 3. 초기화

--- a/web-backend/src/main/java/com/smishingprevention/webbackend/controller/ReportController.java
+++ b/web-backend/src/main/java/com/smishingprevention/webbackend/controller/ReportController.java
@@ -1,24 +1,26 @@
 package com.smishingprevention.webbackend.controller;
 
 import com.smishingprevention.webbackend.dto.ReportDetailResponse;
+import com.smishingprevention.webbackend.dto.WebReportRequestDto; // DTO 임포트 필요
 import com.smishingprevention.webbackend.service.ReportService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/reports") // 이 주소로 호출됨
+@RequestMapping("/api/reports") 
 @RequiredArgsConstructor
-@CrossOrigin(origins = "http://localhost:3000") // 리액트(5173) 접근 허용
+// 리액트 Vite 기본 포트인 5173도 추가해주는 것이 좋습니다.
+@CrossOrigin(origins = {"http://localhost:3000"}) 
 public class ReportController {
 
     private final ReportService reportService;
 
+    // [기존 코드] 커뮤니티 리포트 조회
     @GetMapping
     public ResponseEntity<List<ReportDetailResponse>> getCommunityReports() {
         try {
@@ -27,6 +29,25 @@ public class ReportController {
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    // [추가된 코드] 웹 신고 접수 (이미지 + 데이터)
+    // 호출 주소: POST http://localhost:8080/api/reports/web
+    @PostMapping(value = "/web", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<String> createWebReport(
+            // 프론트에서 formData.append("data", jsonBlob)으로 보낸 JSON 데이터
+            @RequestPart("data") WebReportRequestDto requestDto,
+            // 프론트에서 formData.append("files", file)로 보낸 이미지 파일들 (없을 수도 있음)
+            @RequestPart(value = "files", required = false) List<MultipartFile> files
+    ) {
+        try {
+            // 서비스로 넘겨서 처리 (Firestore 저장 + Storage 업로드)
+            String reportId = reportService.createWebReport(requestDto, files);
+            return ResponseEntity.ok(reportId);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.internalServerError().body("신고 접수 실패: " + e.getMessage());
         }
     }
 }

--- a/web-backend/src/main/java/com/smishingprevention/webbackend/dto/WebReportRequestDto.java
+++ b/web-backend/src/main/java/com/smishingprevention/webbackend/dto/WebReportRequestDto.java
@@ -1,0 +1,15 @@
+package com.smishingprevention.webbackend.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class WebReportRequestDto {
+    private String reporterUid; // [추가] 신고자 UID
+    private String phoneNumber;
+    private String url;
+    private String bankAccount;
+    private String keywords;
+    private String description;
+}

--- a/web-backend/src/main/java/com/smishingprevention/webbackend/service/GeminiService.java
+++ b/web-backend/src/main/java/com/smishingprevention/webbackend/service/GeminiService.java
@@ -1,0 +1,207 @@
+package com.smishingprevention.webbackend.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+public class GeminiService {
+
+    @Value("${gemini.api.key}")
+    private String geminiApiKey;
+
+    // [수정 1] URL에서 '?key=' 제거 (순수 엔드포인트만 남김)
+    private static final String GEMINI_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent";
+
+    private final HttpClient httpClient;
+
+    public GeminiService() {
+        this.httpClient = HttpClient.newHttpClient();
+    }
+
+    public Map<String, Object> analyzeImage(MultipartFile file) {
+        try {
+            System.out.println("========== [Gemini] 분석 요청 시작 ==========");
+            
+            // 1. 이미지 Base64 인코딩
+            String base64Image = Base64.getEncoder().encodeToString(file.getBytes());
+
+            // 2. 요청 바디 생성
+            String requestJson = buildJsonRequest(base64Image);
+            
+            // 3. [수정 2] 헤더에 API 키 추가 (이 방식이 더 안전함)
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(GEMINI_URL)) // URL에는 키 없음
+                    .header("Content-Type", "application/json")
+                    .header("x-goog-api-key", geminiApiKey) // [핵심] 헤더로 키 전송
+                    .POST(HttpRequest.BodyPublishers.ofString(requestJson))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            System.out.println("========== [Gemini] 응답 코드: " + response.statusCode() + " ==========");
+
+            if (response.statusCode() != 200) {
+                System.err.println("!!! [Gemini] 요청 실패 !!!");
+                System.err.println("에러 본문: " + response.body());
+                return new HashMap<>();
+            }
+
+            // 4. 응답 파싱
+            return parseGeminiResponse(response.body());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new HashMap<>();
+        }
+    }
+
+    // JSON 요청 생성
+    private String buildJsonRequest(String base64Image) {
+        String prompt = getPromptText()
+                .replace("\\", "\\\\") 
+                .replace("\"", "\\\"") 
+                .replace("\n", "\\n");
+
+        return """
+            {
+              "contents": [{
+                "parts": [
+                  {"text": "%s"},
+                  {"inline_data": {
+                    "mime_type": "image/jpeg",
+                    "data": "%s"
+                  }}
+                ]
+              }]
+            }
+            """.formatted(prompt, base64Image);
+    }
+
+    // 응답 파싱
+    private Map<String, Object> parseGeminiResponse(String responseBody) {
+        Map<String, Object> result = new HashMap<>();
+        try {
+            int candidatesIndex = responseBody.indexOf("\"candidates\"");
+            if (candidatesIndex == -1) return result;
+
+            int textLabelIndex = responseBody.indexOf("\"text\": \"", candidatesIndex);
+            if (textLabelIndex == -1) return result;
+            
+            int startQuote = textLabelIndex + 9;
+            int endQuote = startQuote;
+            while (true) {
+                endQuote = responseBody.indexOf("\"", endQuote + 1);
+                if (endQuote == -1) break;
+                if (responseBody.charAt(endQuote - 1) != '\\') break;
+            }
+
+            if (endQuote == -1) return result;
+
+            String rawJsonText = responseBody.substring(startQuote, endQuote);
+            String cleanJson = rawJsonText
+                    .replace("\\n", "\n")
+                    .replace("\\\"", "\"")
+                    .replace("\\r", "")
+                    .replaceAll("```json", "")
+                    .replaceAll("```", "")
+                    .trim();
+
+            System.out.println("========== [Gemini] 파싱된 JSON ==========");
+            System.out.println(cleanJson);
+
+            result.put("risk_level", extractValue(cleanJson, "risk_level"));
+            result.put("archetype", extractValue(cleanJson, "archetype"));
+            result.put("action", extractValue(cleanJson, "action"));
+            result.put("summary", extractValue(cleanJson, "summary"));
+            result.put("advice", extractList(cleanJson, "advice"));
+            result.put("risk_factors", extractList(cleanJson, "risk_factors"));
+
+        } catch (Exception e) {
+            System.err.println("[Gemini] 파싱 에러: " + e.getMessage());
+        }
+        return result;
+    }
+
+    private String extractValue(String json, String key) {
+        Pattern pattern = Pattern.compile("\"" + key + "\"\\s*:\\s*\"(.*?)\"");
+        Matcher matcher = pattern.matcher(json);
+        return matcher.find() ? matcher.group(1) : "";
+    }
+
+    private List<String> extractList(String json, String key) {
+        List<String> list = new ArrayList<>();
+        Pattern pattern = Pattern.compile("\"" + key + "\"\\s*:\\s*\\[(.*?)\\]", Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(json);
+        if (matcher.find()) {
+            Matcher itemMatcher = Pattern.compile("\"(.*?)\"").matcher(matcher.group(1));
+            while (itemMatcher.find()) list.add(itemMatcher.group(1));
+        }
+        return list;
+    }
+
+    private String getPromptText() {
+        return """
+            Analyze this screenshot for phishing, smishing, and scams.
+            Read the [REFERENCE GUIDELINES] above carefully and classify the message.
+
+            [REFERENCE GUIDELINES - Use these to classify 'archetype', 'risk_level', and 'action']
+
+            (A) AUTHORITY_IMPERSONATION (기관·공식 사칭)
+            - Context: 검찰/금융기관 사칭 → 사건 연루/계좌 보호 → 안전계좌 이체 유도.
+            - Essential Signals: 기관 사칭, 사건번호/법적 절차 언급, 시간 압박, 송금 요구.
+            - Risk: STOP_IMMEDIATELY.
+
+            (B) ACQUAINTANCE_IMPERSONATION (지인·가족 사칭)
+            - Context: 자녀/친구 사칭 → 폰 고장/분실 → 급전 또는 인증 대행 요구.
+            - Essential Signals: 가족/지인 호칭, 금전 요구.
+            - Risk: WARNING.
+
+            (C) LINK_APP_INDUCTION (링크·앱 유도)
+            - Context: 택배/지원금 문자 → 링크 클릭 → 악성 앱 설치.
+            - Essential Signals: URL 포함, APK 설치 유도.
+            - Risk: WARNING.
+
+            (D) INVESTMENT_SCAM (투자·부업 유혹)
+            - Context: 고수익 보장 → 투자금 입금 요구.
+            - Risk: WARNING or STOP_IMMEDIATELY.
+
+            (E) RELATIONSHIP_SCAM (로맨스 스캠)
+            - Context: 장기간 대화 → 금전 요구.
+            - Risk: WARNING.
+
+            (F) THREAT_SCAM (협박·갈취)
+            - Context: 몸캠/개인정보 유출 협박 → 합의금 요구.
+            - Risk: STOP_IMMEDIATELY.
+
+            [OUTPUT REQUIREMENTS]
+            Based on the analysis, return ONLY a JSON object.
+            
+            1. archetype (Select ONE): AUTHORITY_IMPERSONATION, ACQUAINTANCE_IMPERSONATION, LINK_APP_INDUCTION, INVESTMENT_SCAM, RELATIONSHIP_SCAM, THREAT_SCAM, NORMAL
+            2. risk_level (Select ONE): SAFE, CAUTION, WARNING, STOP_IMMEDIATELY
+            3. action (Select ONE): MONEY_TRANSFER, INSTALL_APP, CLICK_LINK, SHARE_AUTH_CODE, SHARE_PERSONAL_INFO, REMOTE_CONTROL, BUY_GIFT_CARD, KEEP_CALL, NONE
+
+            JSON Structure (Korean):
+            {
+              "risk_level": "Enum",
+              "archetype": "Enum",
+              "action": "Enum",
+              "summary": "1-2 sentence summary in Korean",
+              "risk_factors": ["Factor 1", "Factor 2"],
+              "platform": "App Name",
+              "counterpart_name": "Sender Name",
+              "advice": ["Advice 1", "Advice 2"],
+              "phone_numbers": ["010-xxxx-xxxx"],
+              "urls": ["http://..."]
+            }
+        """;
+    }
+}

--- a/web-backend/src/main/java/com/smishingprevention/webbackend/service/ReportService.java
+++ b/web-backend/src/main/java/com/smishingprevention/webbackend/service/ReportService.java
@@ -1,79 +1,185 @@
 package com.smishingprevention.webbackend.service;
 
 import com.smishingprevention.webbackend.dto.ReportDetailResponse;
+import com.smishingprevention.webbackend.dto.WebReportRequestDto;
 import com.google.api.core.ApiFuture;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Bucket;
 import com.google.cloud.firestore.*;
 import com.google.firebase.cloud.FirestoreClient;
+import com.google.firebase.cloud.StorageClient;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
+@RequiredArgsConstructor
 public class ReportService {
 
+    private final GeminiService geminiService;
+
+    private static final String COLLECTION_WEB = "web_reports";
+    private static final String COLLECTION_APP = "community_reports";
+    private static final String STORAGE_FOLDER = "web_reports_images/";
+
+    /**
+     * [수정됨] 커뮤니티 리포트 + 웹 리포트 통합 조회 (최신순 정렬)
+     */
     public List<ReportDetailResponse> getAllReportsWithUserInfo() throws ExecutionException, InterruptedException {
         Firestore db = FirestoreClient.getFirestore();
         List<ReportDetailResponse> responseList = new ArrayList<>();
 
-        // 1. 커뮤니티 리포트 전체 가져오기 (최신순 정렬)
-        // 만약 인덱스 에러가 나면 .orderBy 부분을 잠시 지우세요.
-        ApiFuture<QuerySnapshot> future = db.collection("community_reports")
-                                            .orderBy("timestamp", Query.Direction.DESCENDING)
-                                            .get();
-        
-        List<QueryDocumentSnapshot> documents = future.get().getDocuments();
+        // 1. 두 컬렉션 동시에 비동기 조회 (속도 향상)
+        // 앱 신고 내역
+        ApiFuture<QuerySnapshot> appFuture = db.collection(COLLECTION_APP).get();
+        // 웹 신고 내역
+        ApiFuture<QuerySnapshot> webFuture = db.collection(COLLECTION_WEB).get();
 
-        // 2. 각 게시글마다 작성자 정보 조회 (Loop)
-        for (QueryDocumentSnapshot document : documents) {
-            String reporterUid = document.getString("reporterUid");
-            
-            // 유저 정보 기본값 (탈퇴했거나 정보가 없을 경우 대비)
-            String nickname = "알 수 없음";
-            String region = "지역 미설정";
-            String age = "알 수 없음";
-            String job = "직업 미상";
+        // 2. 결과 가져오기
+        List<QueryDocumentSnapshot> appDocs = appFuture.get().getDocuments();
+        List<QueryDocumentSnapshot> webDocs = webFuture.get().getDocuments();
 
-            // 3. reporterUid가 있으면 Users 컬렉션에서 조회
-            if (reporterUid != null && !reporterUid.isEmpty()) {
-                DocumentSnapshot userDoc = db.collection("users").document(reporterUid).get().get();
-                
-                if (userDoc.exists()) {
-                    nickname = userDoc.getString("nickname");
-                    region = userDoc.getString("region");
-                    job = userDoc.getString("job");
-                    
-                    // 생년월일("20020919") -> 나이("25세") 변환
-                    String birthStr = userDoc.getString("birth");
-                    age = calculateAge(birthStr);
-                }
-            }
-
-            // 4. DTO 생성 및 리스트 추가
-            ReportDetailResponse dto = ReportDetailResponse.builder()
-                    .id(document.getId())
-                    .summary(document.getString("summary"))
-                    .riskLevel(document.getString("riskLevel"))
-                    .timestamp(document.getLong("timestamp")) // Firestore Timestamp는 Long으로 받음
-                    .advice(document.getString("advice"))
-                    .contextInfo(document.getString("contextInfo"))
-                    .imageUrl(document.getString("imageUrl"))
-                    // 유저 정보 매핑
-                    .reporterNickname(nickname)
-                    .reporterRegion(region)
-                    .reporterAge(age)
-                    .reporterJob(job)
-                    .build();
-
-            responseList.add(dto);
+        // 3. 앱 신고 데이터 변환 및 추가
+        for (QueryDocumentSnapshot doc : appDocs) {
+            responseList.add(convertDocumentToDto(db, doc));
         }
+
+        // 4. 웹 신고 데이터 변환 및 추가
+        for (QueryDocumentSnapshot doc : webDocs) {
+            responseList.add(convertDocumentToDto(db, doc));
+        }
+
+        // 5. [중요] 타임스탬프 기준 내림차순 정렬 (최신글이 위로)
+        responseList.sort((r1, r2) -> Long.compare(r2.getTimestamp(), r1.getTimestamp()));
 
         return responseList;
     }
 
-    // 나이 계산 함수 (한국식 나이: 현재연도 - 태어난연도 + 1)
+    /**
+     * [Helper] Firestore 문서를 DTO로 변환하는 공통 메서드
+     */
+    private ReportDetailResponse convertDocumentToDto(Firestore db, QueryDocumentSnapshot document) {
+        String reporterUid = document.getString("reporterUid");
+        
+        String nickname = "알 수 없음";
+        String region = "지역 미설정";
+        String age = "알 수 없음";
+        String job = "직업 미상";
+
+        // 사용자 정보 조회 (예외 발생해도 게시글은 보이도록 try-catch)
+        if (reporterUid != null && !reporterUid.isEmpty()) {
+            try {
+                DocumentSnapshot userDoc = db.collection("users").document(reporterUid).get().get();
+                if (userDoc.exists()) {
+                    nickname = userDoc.getString("nickname");
+                    region = userDoc.getString("region");
+                    job = userDoc.getString("job");
+                    age = calculateAge(userDoc.getString("birth"));
+                }
+            } catch (Exception e) {
+                // 유저 정보 조회 실패 시 기본값 유지
+                System.err.println("유저 정보 조회 실패 (" + reporterUid + "): " + e.getMessage());
+            }
+        }
+
+        return ReportDetailResponse.builder()
+                .id(document.getId())
+                .summary(document.getString("summary"))
+                .riskLevel(document.getString("riskLevel"))
+                .timestamp(document.getLong("timestamp"))
+                .advice(document.getString("advice"))
+                .contextInfo(document.getString("contextInfo"))
+                .imageUrl(document.getString("imageUrl"))
+                // DTO에 정의된 필드에 맞춰 DB 값 매핑 (없는 필드는 null 처리됨)
+                .reporterNickname(nickname)
+                .reporterRegion(region)
+                .reporterAge(age)
+                .reporterJob(job)
+                .build();
+    }
+
+    /**
+     * [신규 기능] 웹 신고 접수
+     */
+    public String createWebReport(WebReportRequestDto dto, List<MultipartFile> files) {
+        Firestore db = FirestoreClient.getFirestore();
+
+        try {
+            DocumentReference docRef = db.collection(COLLECTION_WEB).document();
+            String docId = docRef.getId();
+
+            String mainImageUrl = "";
+            Map<String, Object> aiResult = new HashMap<>();
+            String userFolder = (dto.getReporterUid() != null && !dto.getReporterUid().isEmpty()) 
+                                ? dto.getReporterUid() : "anonymous";
+
+            if (files != null && !files.isEmpty()) {
+                MultipartFile file = files.get(0);
+                if (!file.isEmpty()) {
+                    Bucket bucket = StorageClient.getInstance().bucket();
+                    String blobName = STORAGE_FOLDER + userFolder + "/" + file.getOriginalFilename();
+
+                    bucket.create(blobName, file.getBytes(), file.getContentType());
+                    
+                    mainImageUrl = "https://firebasestorage.googleapis.com/v0/b/" + bucket.getName() + "/o/"
+                            + blobName.replace("/", "%2F") + "?alt=media";
+
+                    aiResult = geminiService.analyzeImage(file);
+                }
+            }
+
+            Map<String, Object> data = new HashMap<>();
+            data.put("id", docId);
+            data.put("reporterUid", dto.getReporterUid());
+            data.put("timestamp", System.currentTimeMillis());
+            data.put("platform", "web");
+            data.put("status", "analyzed");
+
+            data.put("riskLevel", aiResult.getOrDefault("risk_level", "PENDING"));
+            data.put("archetype", aiResult.getOrDefault("archetype", "UNKNOWN"));
+            data.put("action", aiResult.getOrDefault("action", "NONE"));
+            data.put("summary", aiResult.getOrDefault("summary", "분석 대기 중입니다."));
+            data.put("advice", formatListToString(aiResult.get("advice")));
+            data.put("riskFactors", formatListToString(aiResult.get("risk_factors")));
+
+            String contextInfo = String.format("📱 앱: 웹 신고 👤 상대: %s", dto.getPhoneNumber());
+            data.put("contextInfo", contextInfo);
+
+            String urlInfo = (dto.getUrl() != null && !dto.getUrl().isEmpty()) ? dto.getUrl() : "없음";
+            String phoneReport = String.format("✅ %s : (정보없음) 🔗 URL: %s", dto.getPhoneNumber(), urlInfo);
+            data.put("phoneReport", phoneReport);
+
+            data.put("imageUrl", mainImageUrl);
+            data.put("urlPreviewUrl", "");
+
+            docRef.set(data).get();
+
+            return docId;
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("신고 저장 실패: " + e.getMessage());
+        }
+    }
+
+    private String formatListToString(Object listObj) {
+        if (listObj instanceof List<?>) {
+            List<?> list = (List<?>) listObj;
+            if (list.isEmpty()) return "";
+            return list.stream()
+                    .map(Object::toString)
+                    .map(s -> "• " + s)
+                    .collect(Collectors.joining(" "));
+        }
+        return "";
+    }
+
     private String calculateAge(String birthStr) {
         if (birthStr == null || birthStr.length() != 8) return "알 수 없음";
         try {

--- a/web-backend/src/main/resources/application.properties
+++ b/web-backend/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 spring.application.name=web-backend
 
 # APick API 설정
-apick.api.key=ApickApi
+apick.api.key=API_Key
 apick.api.url=https://apick.app/rest/check_spam_number
+
+gemini.api.key=API_Key

--- a/web-frontend/src/app/components/ReportSection.tsx
+++ b/web-frontend/src/app/components/ReportSection.tsx
@@ -1,134 +1,180 @@
-import { Plus } from "lucide-react";
-import { Button } from "@/app/components/ui/button";
-import { Card } from "@/app/components/ui/card";
-import { Input } from "@/app/components/ui/input";
-import { Label } from "@/app/components/ui/label";
-import { Textarea } from "@/app/components/ui/textarea";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/app/components/ui/select";
-import { useState } from "react";
+import { useState, useRef } from "react";
+
+// 데이터 타입 정의
+export interface CriminalData {
+  phoneNumber: string;
+  url: string;
+  bankAccount: string;
+  keywords: string;
+  description: string;
+}
 
 interface ReportSectionProps {
-  onReport: (data: CriminalData) => void;
+  onReport: (data: CriminalData, files: File[]) => void;
+  isSubmitting?: boolean;
 }
 
-export interface CriminalData {
-  phone?: string;
-  url?: string;
-  account?: string;
-  keyword?: string;
-  description?: string;
-}
+export function ReportSection({ onReport, isSubmitting = false }: ReportSectionProps) {
+  // 입력값 상태 관리
+  const [formData, setFormData] = useState<CriminalData>({
+    phoneNumber: "",
+    url: "",
+    bankAccount: "",
+    keywords: "",
+    description: "",
+  });
 
-export function ReportSection({ onReport }: ReportSectionProps) {
-  const [formData, setFormData] = useState<CriminalData>({});
+  // 파일 상태 관리
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const handleSubmit = () => {
-    if (
-      formData.phone ||
-      formData.url ||
-      formData.account ||
-      formData.keyword
-    ) {
-      onReport(formData);
-      setFormData({});
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  // 파일 선택 핸들러 (여러 장 선택 가능)
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      const newFiles = Array.from(e.target.files);
+      setSelectedFiles((prev) => [...prev, ...newFiles]);
     }
   };
 
+  // 파일 삭제 핸들러 (인덱스로 삭제)
+  const removeFile = (indexToRemove: number) => {
+    setSelectedFiles((prev) => prev.filter((_, index) => index !== indexToRemove));
+  };
+
+  const handleSubmit = () => {
+    // 필수값 체크 등 유효성 검사 필요 시 여기에 추가
+    onReport(formData, selectedFiles);
+  };
+
   return (
-    <div className="bg-white dark:bg-gray-900 rounded-2xl p-5 shadow-sm border border-gray-100 dark:border-gray-800">
-      <div className="flex items-center gap-2 mb-4">
-        <div className="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg">
-          <Plus className="w-5 h-5 text-gray-900 dark:text-white" />
-        </div>
-        <h2 className="font-semibold">범죄자 신고</h2>
-      </div>
+    <div className="w-full max-w-md mx-auto space-y-4">
+      
+      {/* 1. 범죄자 신고 헤더 카드 (기존 디자인 유지) */}
+      <div className="bg-white rounded-2xl p-5 shadow-sm border border-gray-100">
+        <h2 className="text-lg font-bold flex items-center gap-2">
+          <span>+</span> 범죄자 신고
+        </h2>
+        
+        <div className="mt-4 space-y-4">
+          {/* 전화번호 입력 */}
+          <div>
+            <label className="text-xs font-semibold text-gray-500 ml-1">전화번호</label>
+            <input
+              name="phoneNumber"
+              value={formData.phoneNumber}
+              onChange={handleChange}
+              placeholder="010-1234-5678"
+              className="w-full mt-1 p-3 bg-gray-50 rounded-xl text-sm outline-none focus:ring-2 focus:ring-black/5 transition-all"
+            />
+          </div>
 
-      <div className="space-y-4">
-        <div>
-          <Label htmlFor="phone" className="text-sm font-medium mb-2 block">
-            전화번호
-          </Label>
-          <Input
-            id="phone"
-            className="h-12 rounded-xl"
-            placeholder="010-1234-5678"
-            value={formData.phone || ""}
-            onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
-          />
-        </div>
+          {/* URL/도메인 입력 */}
+          <div>
+            <label className="text-xs font-semibold text-gray-500 ml-1">URL/도메인</label>
+            <input
+              name="url"
+              value={formData.url}
+              onChange={handleChange}
+              placeholder="example.com"
+              className="w-full mt-1 p-3 bg-gray-50 rounded-xl text-sm outline-none focus:ring-2 focus:ring-black/5 transition-all"
+            />
+          </div>
 
-        <div>
-          <Label htmlFor="url" className="text-sm font-medium mb-2 block">
-            URL/도메인
-          </Label>
-          <Input
-            id="url"
-            className="h-12 rounded-xl"
-            placeholder="example.com"
-            value={formData.url || ""}
-            onChange={(e) => setFormData({ ...formData, url: e.target.value })}
-          />
-        </div>
+          {/* 계좌번호 입력 */}
+          <div>
+            <label className="text-xs font-semibold text-gray-500 ml-1">계좌번호</label>
+            <input
+              name="bankAccount"
+              value={formData.bankAccount}
+              onChange={handleChange}
+              placeholder="123456-78-901234"
+              className="w-full mt-1 p-3 bg-gray-50 rounded-xl text-sm outline-none focus:ring-2 focus:ring-black/5 transition-all"
+            />
+          </div>
 
-        <div>
-          <Label htmlFor="account" className="text-sm font-medium mb-2 block">
-            계좌번호
-          </Label>
-          <Input
-            id="account"
-            className="h-12 rounded-xl"
-            placeholder="123456-78-901234"
-            value={formData.account || ""}
-            onChange={(e) =>
-              setFormData({ ...formData, account: e.target.value })
-            }
-          />
-        </div>
+          {/* 사칭 키워드 입력 */}
+          <div>
+            <label className="text-xs font-semibold text-gray-500 ml-1">사칭 키워드</label>
+            <input
+              name="keywords"
+              value={formData.keywords}
+              onChange={handleChange}
+              placeholder="예: 경찰청, 검찰청 등"
+              className="w-full mt-1 p-3 bg-gray-50 rounded-xl text-sm outline-none focus:ring-2 focus:ring-black/5 transition-all"
+            />
+          </div>
 
-        <div>
-          <Label htmlFor="keyword" className="text-sm font-medium mb-2 block">
-            사칭 키워드
-          </Label>
-          <Input
-            id="keyword"
-            className="h-12 rounded-xl"
-            placeholder="예: 경찰청, 검찰청 등"
-            value={formData.keyword || ""}
-            onChange={(e) =>
-              setFormData({ ...formData, keyword: e.target.value })
-            }
-          />
-        </div>
+          {/* === [증거 사진 첨부 영역] === */}
+          <div>
+            <label className="text-xs font-semibold text-gray-500 ml-1">증거 사진 (선택)</label>
+            <div className="mt-1 flex gap-2 overflow-x-auto pb-2 scrollbar-hide">
+              {/* 사진 추가 버튼 */}
+              <button 
+                onClick={() => fileInputRef.current?.click()}
+                className="flex-shrink-0 w-20 h-20 bg-gray-50 rounded-xl flex flex-col items-center justify-center text-gray-400 hover:bg-gray-100 transition-colors border border-dashed border-gray-300"
+              >
+                <span className="text-xl">+</span>
+                <span className="text-[10px] mt-1">사진 추가</span>
+              </button>
 
-        <div>
-          <Label htmlFor="description" className="text-sm font-medium mb-2 block">
-            상세 설명 (선택)
-          </Label>
-          <Textarea
-            id="description"
-            className="rounded-xl"
-            placeholder="범죄 내용을 상세히 적어주세요"
-            value={formData.description || ""}
-            onChange={(e) =>
-              setFormData({ ...formData, description: e.target.value })
-            }
-            rows={3}
-          />
-        </div>
+              {/* 선택된 사진 미리보기 리스트 */}
+              {selectedFiles.map((file, idx) => (
+                <div key={idx} className="relative flex-shrink-0 w-20 h-20 bg-gray-100 rounded-xl overflow-hidden border border-gray-200 group">
+                  <img 
+                    src={URL.createObjectURL(file)} 
+                    alt="preview" 
+                    className="w-full h-full object-cover" 
+                  />
+                  {/* 삭제 버튼 (호버 시 더 잘 보이게 조정) */}
+                  <button 
+                    onClick={() => removeFile(idx)}
+                    className="absolute top-0 right-0 w-6 h-6 bg-black/60 text-white flex items-center justify-center rounded-bl-lg text-xs hover:bg-black/80 transition-colors"
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+            </div>
 
-        <Button
-          onClick={handleSubmit}
-          className="w-full h-12 rounded-xl bg-gray-900 hover:bg-gray-800 dark:bg-white dark:hover:bg-gray-200 dark:text-gray-900 mt-2"
-        >
-          <Plus className="w-4 h-4 mr-2" />
-          신고하기
-        </Button>
+            {/* 숨겨진 파일 인풋 (multiple 속성으로 여러 장 선택 가능) */}
+            <input 
+              type="file" 
+              multiple 
+              accept="image/*" 
+              ref={fileInputRef} 
+              className="hidden" 
+              onChange={handleFileChange}
+            />
+          </div>
+          {/* ========================================================= */}
+
+          {/* 상세 설명 (선택) */}
+          <div>
+            <label className="text-xs font-semibold text-gray-500 ml-1">상세 설명 (선택)</label>
+            <textarea
+              name="description"
+              value={formData.description}
+              onChange={handleChange}
+              placeholder="범죄 내용을 상세히 적어주세요"
+              className="w-full mt-1 p-3 bg-gray-50 rounded-xl text-sm outline-none focus:ring-2 focus:ring-black/5 transition-all h-24 resize-none"
+            />
+          </div>
+
+          {/* 신고하기 버튼 */}
+          <button
+            onClick={handleSubmit}
+            disabled={isSubmitting}
+            className="w-full bg-[#0f172a] text-white py-4 rounded-xl font-bold text-sm hover:bg-[#1e293b] active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed shadow-md shadow-slate-200"
+          >
+            {isSubmitting ? "접수 중..." : "+ 신고하기"}
+          </button>
+
+        </div>
       </div>
     </div>
   );

--- a/web-frontend/src/pages/ReportPage.tsx
+++ b/web-frontend/src/pages/ReportPage.tsx
@@ -1,16 +1,68 @@
+import { useState } from "react";
 import { toast } from "sonner";
+import axios from "axios";
+import { getAuth } from "firebase/auth"; // [추가] Firebase Auth 임포트
 import { ReportSection } from "@/app/components/ReportSection";
 import type { CriminalData } from "@/app/components/ReportSection";
 
 export default function ReportPage() {
-  const handleReport = (data: CriminalData) => {
-    void data;
-    toast.success("신고가 접수되었습니다. 검토 후 등록됩니다.");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const API_URL = "http://localhost:8080/api/reports/web"; 
+
+  const handleReport = async (data: CriminalData, files: File[]) => {
+    if (isSubmitting) return;
+
+    // [추가] 현재 로그인한 유저 UID 가져오기
+    const auth = getAuth();
+    const currentUser = auth.currentUser;
+
+    if (!currentUser) {
+      toast.error("로그인이 필요한 서비스입니다.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    const loadingToast = toast.loading("신고를 안전하게 접수하고 있습니다...");
+
+    try {
+      const formData = new FormData();
+      
+      // [수정] 데이터 객체에 reporterUid 추가하여 전송
+      const reportData = {
+        ...data,
+        reporterUid: currentUser.uid // UID 추가
+      };
+
+      const jsonBlob = new Blob([JSON.stringify(reportData)], { type: "application/json" });
+      formData.append("data", jsonBlob);
+
+      files.forEach((file) => {
+        formData.append("files", file);
+      });
+
+      await axios.post(API_URL, formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+
+      toast.dismiss(loadingToast);
+      toast.success("신고가 성공적으로 접수되었습니다!");
+
+    } catch (error) {
+      console.error("Report Error:", error);
+      toast.dismiss(loadingToast);
+      toast.error("신고 접수에 실패했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
-    <div className="p-4">
-      <ReportSection onReport={handleReport} />
+    <div className="p-4 bg-gray-50/30 min-h-screen">
+      <div className="max-w-md mx-auto mb-6">
+        <h1 className="text-xl font-bold px-1">신고하기</h1>
+        <p className="text-sm text-gray-500 px-1">의심 사례를 접수하세요</p>
+      </div>
+      <ReportSection onReport={handleReport} isSubmitting={isSubmitting} />
     </div>
   );
 }

--- a/web-frontend/src/pages/SignupPage.tsx
+++ b/web-frontend/src/pages/SignupPage.tsx
@@ -45,8 +45,6 @@ export default function SignupPage() {
         region: region,
         job: job,
         createdAt: Number(Date.now()), // Number 타입 타임스탬프
-        recentSearchCount: 0, // 홈 화면 연동용 초기값
-        recentReportCount: 0
       });
 
       navigate("/");


### PR DESCRIPTION
## Summary
웹 프론트엔드에서 접수된 피싱 의심 신고 내용을 Gemini AI를 통해 분석하여 저장하고, 커뮤니티 페이지에서 기존 앱 신고 내역(`community_reports`)과 웹 신고 내역(`web_reports`)을 통합하여 최신순으로 조회할 수 있도록 백엔드 로직을 구현했습니다.

## Changes
- **GeminiService.java 추가**: 
    - 외부 라이브러리(Jackson) 없이 Java 11 `HttpClient`와 정규표현식을 사용하여 Gemini API와 통신하도록 구현했습니다.
    - 이미지 Base64 인코딩 및 헤더(`x-goog-api-key`) 인증 방식을 적용하여 보안성을 높였습니다.
- **ReportService.java 수정**:
    - `createWebReport`: 신고 접수 시 AI 분석 결과를 파싱하여 `riskLevel`, `archetype`, `advice` 등의 필드로 DB에 저장하도록 로직을 추가했습니다.
    - `getAllReportsWithUserInfo`: `ApiFuture`를 사용하여 두 개의 Firestore 컬렉션을 비동기로 동시에 조회 후 병합하도록 개선했습니다.
    - `convertDocumentToDto`: DTO 변환 로직을 분리하고, 필수 필드 누락 시 500 에러가 발생하지 않도록 Null Safety 처리를 강화했습니다.
    - `timestamp` 기준으로 내림차순 정렬 로직을 수정했습니다 (Primitive type 비교 오류 해결).

## Testing
- [ ] Not run (reason):
- [ ] Unit
- [ ] Integration
- [x] Manual

**Test Scenario:**
1. 웹에서 이미지가 포함된 신고를 제출했을 때, 콘솔에 Gemini API 응답 로그가 정상적으로 출력되는지 확인.
2. Firestore `web_reports` 컬렉션에 AI 분석 결과(`riskLevel`, `archetype` 등)가 저장되는지 확인.
3. 커뮤니티 목록 조회 API(`/api/reports`) 호출 시, 500 에러 없이 앱/웹 신고가 섞여서 최신순으로 정렬되는지 확인.

## Risks / Rollback

**Risk:**
- Gemini API 키가 만료되거나 할당량이 초과될 경우 분석 기능이 작동하지 않을 수 있음 (기본값 저장 처리됨).
- Firestore 데이터 구조가 변경될 경우 DTO 변환 로직에서 예외가 발생할 수 있음.

**Rollback plan:**
- 배포 후 심각한 오류 발생 시 `main` 브랜치의 이전 커밋으로 `revert` 수행.
- 로컬 환경에서 `git checkout main` 후 다시 빌드하여 배포.

## References

**Related:**
- Issue: Closes #20
- Feature Branch: `feature/dashboard-fix`

