### PR TITLE
fix : 로그인 안된 사용자 로그인 화면 넘기기

### DIFF
--- a/web-frontend/src/pages/ReportPage.tsx
+++ b/web-frontend/src/pages/ReportPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { toast } from "sonner";
+import { useNavigate } from 'react-router-dom';
 import axios from "axios";
 import { getAuth } from "firebase/auth"; // [추가] Firebase Auth 임포트
 import { ReportSection } from "@/app/components/ReportSection";
@@ -8,6 +9,7 @@ import type { CriminalData } from "@/app/components/ReportSection";
 export default function ReportPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const API_URL = "http://localhost:8080/api/reports/web"; 
+  const navigate = useNavigate();
 
   const handleReport = async (data: CriminalData, files: File[]) => {
     if (isSubmitting) return;
@@ -16,8 +18,10 @@ export default function ReportPage() {
     const auth = getAuth();
     const currentUser = auth.currentUser;
 
+
     if (!currentUser) {
       toast.error("로그인이 필요한 서비스입니다.");
+      navigate('/login'); // 로그인 페이지 경로로 이동 (만약 회원가입 페이지라면 '/signup'으로 변경)
       return;
     }
 


### PR DESCRIPTION
# fix: 신고 페이지 비로그인 리다이렉트 로직 추가 및 보안 파일 제거

## Summary
신고 페이지(`ReportPage`)에서 로그인 여부를 확인하여 비로그인 사용자를 로그인 페이지로 강제 이동시키는 로직을 추가하고, 실수로 포함되었던 `serviceAccountKey.json` 파일을 제거하여 보안 위험을 해소했습니다.

## Changes
- **ReportPage.tsx 수정**: 
    - `useNavigate` 훅을 도입하여 `currentUser`가 `null`일 경우 `/login` 경로로 리다이렉트하도록 수정했습니다.
    - Hook 규칙(Rules of Hooks) 준수를 위해 `Maps` 변수 선언 위치를 컴포넌트 최상단으로 이동했습니다.
- **보안 파일 제거**:
    - `web-backend/src/main/resources/serviceAccountKey.json` 파일을 Git 추적에서 제외하고 삭제했습니다.
- **firebase.ts 수정**:
    - (해당 파일에 변경 사항이 있다면) 불필요한 공백 또는 설정 코드를 정리했습니다.

## Testing
- [ ] Not run (reason):
- [ ] Unit
- [ ] Integration
- [x] Manual

**Test Scenario:**
1. 로그아웃 상태에서 신고 페이지 URL로 접근하거나 버튼을 클릭한다.
2. "로그인이 필요한 서비스입니다." 토스트 메시지가 뜨는지 확인한다.
3. 자동으로 로그인 페이지로 화면이 전환되는지 확인한다.
4. PR의 Files Changed 탭에서 `serviceAccountKey.json`이 삭제(Deleted) 상태인지 확인한다.

## Risks / Rollback

**Risk:**
- `useNavigate` 경로(`/login`)가 실제 라우터 설정과 다를 경우 404 페이지로 이동할 수 있음.

**Rollback plan:**
- 문제 발생 시 이전 커밋으로 `revert` 수행.

## References

**Related:**
- Issue: Closes #23 